### PR TITLE
Persist PromptFolder index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ pysssss.json
 user/autocomplete.txt
 web/js/assets/favicon.user.ico
 web/js/assets/favicon-active.user.ico
+user/prompt_folder_state.json


### PR DESCRIPTION
## Summary
- persist state for PromptFolder node in `user/prompt_folder_state.json`
- add an `index` input to start from a specific prompt
- ignore user state file

## Testing
- `python -m py_compile py/prompt_folder.py`


------
https://chatgpt.com/codex/tasks/task_e_6847b4b06e3c832bace51d380291fd34