### PR TITLE
Persist state for PromptFolderAdvanced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ user/autocomplete.txt
 web/js/assets/favicon.user.ico
 web/js/assets/favicon-active.user.ico
 user/prompt_folder_state.json
+user/prompt_folder_advanced_state.json


### PR DESCRIPTION
## Summary
- make advanced prompt folder node keep state between executions
- ignore saved state file

## Testing
- `pytest -q`
- `python -m py_compile py/prompt_folder_advanced.py`


------
https://chatgpt.com/codex/tasks/task_e_6847d3040e64832bb4759111bfad6a00